### PR TITLE
HMRC-1458: Limit prod deploy trigger to main branch only

### DIFF
--- a/.github/workflows/deploy-to-development.yml
+++ b/.github/workflows/deploy-to-development.yml
@@ -1,10 +1,10 @@
 name: Lint, Test and Deploy to Development
 
 on:
+  workflow_dispatch:
   push:
     branches-ignore:
       - main
-  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -1,11 +1,13 @@
 name: Deploy to Production
 
 on:
+  workflow_dispatch:
   workflow_run:
     workflows: ["Deploy to Staging"]
     types:
       - completed
-  workflow_dispatch:
+    branches:
+      - main
 
 permissions:
       id-token: write
@@ -20,7 +22,7 @@ env:
 
 jobs:
   deploy:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -1,10 +1,10 @@
 name: Deploy to Staging
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
-  workflow_dispatch:
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # trade-tariff-lambdas-fpo-model-garbage-collection
+
 Scheduled go lambda function to garbage collect dead models.


### PR DESCRIPTION
# Pull request

## Jira Link

[HMRC-1458](https://transformuk.atlassian.net/browse/HMRC-1458)

## What?

I have added/removed/altered:

- [x] added a condition to the production workflow so it only runs if the staging workflow was triggered from the main branch

## Why?

I am doing this because:

- Ensure production is only deployed after a successful automated staging deployment from the main branch

## AC

-
-
-
