### PR TITLE
HMRC-715: Add log retention

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,26 +1,26 @@
 ---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
 
   - repo: https://github.com/zahorniak/pre-commit-circleci.git
-    rev: v1.1.0
+    rev: v1.2.0
     hooks:
       - id: circleci_validate
         args:
           - --org-id=da607531-93bb-4321-90ed-08710434ce1c
 
   - repo: https://github.com/trufflesecurity/trufflehog
-    rev: v3.88.23
+    rev: v3.90.12
     hooks:
       - id: trufflehog
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.44.0
+    rev: v0.45.0
     hooks:
       - id: markdownlint-docker
         args:
@@ -29,7 +29,7 @@ repos:
           - "--fix"
 
   - repo: https://github.com/golangci/golangci-lint
-    rev: v2.0.2
+    rev: v2.6.0
     hooks:
       - id: golangci-lint-full
         entry: "bash -c 'cd collector'"

--- a/serverless.yml
+++ b/serverless.yml
@@ -36,3 +36,17 @@ functions:
     handler: bootstrap
     events:
       - schedule: cron(0 12 * * ? *) # Run every day at 12 PM
+
+custom:
+  logRetentionInDays:
+    development: 7
+    staging: 14
+    production: 30
+
+resources:
+  Resources:
+    CollectorLogGroup:
+      Type: AWS::Logs::LogGroup
+      Properties:
+        LogGroupName: /aws/lambda/${self:service}-${env:STAGE}-collector
+        RetentionInDays: ${self:custom.logRetentionInDays.${env:STAGE}, 14}


### PR DESCRIPTION
# Pull request

## Jira Link

[HMRC-1715](https://transformuk.atlassian.net/browse/HMRC-1715)

## What?

I have added/removed/altered:

- [x] Added CloudWatch LogGroup resources for Lambda
- [x] Configurable retention per stage (dev/staging/prod).

## Why?

I am doing this because:

- Explicit log groups ensure logs are retained for the correct duration and help manage costs.

## AC

-
-
-
