### PR TITLE
OTTIMP-400: Use shared TruffleHog pre-commit runner

### DIFF
--- a/.github/bin/trufflehog
+++ b/.github/bin/trufflehog
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-docker run --rm -v "$(pwd):/workdir" \
-  -i \
-  --rm trufflesecurity/trufflehog:latest \
-  git file:///workdir --since-commit HEAD --results=verified,unknown --fail
+tmp_file="$(mktemp)"
+trap 'rm -f "$tmp_file"' EXIT
+
+curl -fsSL \
+  https://raw.githubusercontent.com/trade-tariff/trade-tariff-tools/main/scripts/trufflehog-pre-commit.sh \
+  -o "$tmp_file"
+
+bash "$tmp_file" "$(pwd)"


### PR DESCRIPTION
### Jira link

[OTTIMP-400](https://transformuk.atlassian.net/browse/OTTIMP-400)

### What?

- [x] replace the repo-local TruffleHog implementation with a lightweight wrapper
- [x] fetch the shared runner from `trade-tariff-tools` on `main`
- [x] switch the local pre-commit scan path to the shared worktree-safe filesystem runner

### Why?

The existing local wrapper shells into Docker and asks TruffleHog to scan `git file:///workdir`.
That breaks in git worktrees because the worktree `.git` file points at host paths that do not exist inside the container.

Using the shared runner keeps the fix in one place and makes the local pre-commit hook work in worktrees again.
