### PR TITLE
BAU: Add workflow to close stale pull requests

### DIFF
--- a/.github/workflows/close-stale-pull-requests.yml
+++ b/.github/workflows/close-stale-pull-requests.yml
@@ -33,4 +33,3 @@ jobs:
       stale_days: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.stale_days != '' && fromJSON(github.event.inputs.stale_days) || 14 }}
       keep_label: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.keep_label != '' && github.event.inputs.keep_label || 'keep' }}
       dry_run: ${{ github.event_name != 'schedule' && (github.event.inputs.dry_run != 'false') }}
-

--- a/.github/workflows/close-stale-pull-requests.yml
+++ b/.github/workflows/close-stale-pull-requests.yml
@@ -8,7 +8,7 @@ on:
       stale_days:
         description: Days without pull request activity before closure
         required: false
-        default: '90'
+        default: '14'
       keep_label:
         description: Label exempting a pull request from closure
         required: false
@@ -30,7 +30,7 @@ jobs:
   close-stale:
     uses: trade-tariff/trade-tariff-tools/.github/workflows/close-stale-pull-requests-reusable.yml@main
     with:
-      stale_days: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.stale_days != '' && fromJSON(github.event.inputs.stale_days) || 90 }}
+      stale_days: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.stale_days != '' && fromJSON(github.event.inputs.stale_days) || 14 }}
       keep_label: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.keep_label != '' && github.event.inputs.keep_label || 'keep' }}
       dry_run: ${{ github.event_name != 'schedule' && (github.event.inputs.dry_run != 'false') }}
 

--- a/.github/workflows/close-stale-pull-requests.yml
+++ b/.github/workflows/close-stale-pull-requests.yml
@@ -1,0 +1,36 @@
+name: Close stale pull requests
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+    inputs:
+      stale_days:
+        description: Days without pull request activity before closure
+        required: false
+        default: '90'
+      keep_label:
+        description: Label exempting a pull request from closure
+        required: false
+        default: keep
+      dry_run:
+        description: Dry run only (true/false)
+        required: false
+        default: 'true'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  close-stale:
+    uses: trade-tariff/trade-tariff-tools/.github/workflows/close-stale-pull-requests-reusable.yml@main
+    with:
+      stale_days: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.stale_days != '' && fromJSON(github.event.inputs.stale_days) || 90 }}
+      keep_label: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.keep_label != '' && github.event.inputs.keep_label || 'keep' }}
+      dry_run: ${{ github.event_name != 'schedule' && (github.event.inputs.dry_run != 'false') }}
+

--- a/.github/workflows/deploy-to-development.yml
+++ b/.github/workflows/deploy-to-development.yml
@@ -25,7 +25,7 @@ jobs:
 
         - uses: actions/setup-go@v5
           with:
-            go-version: '1.23'
+            go-version: '1.24'
 
         - run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 
@@ -52,7 +52,7 @@ jobs:
 
         - uses: actions/setup-go@v5
           with:
-            go-version: '1.23'
+            go-version: '1.24'
 
         - run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
         - run: make test


### PR DESCRIPTION
### Jira link

_No Jira story — BAU automation._

### What?

- [x] Add a scheduled and manually dispatchable workflow to close stale open pull requests
- [x] Skip pull requests labelled `keep` (configurable on manual dispatch)
- [x] Default to dry run on manual dispatch; scheduled runs close matching pull requests

### Why?

Long-lived open pull requests accumulate across the organisation. This automation closes pull requests with no recent activity after a configurable period, while allowing teams to exempt specific pull requests with a `keep` label.

### Risk

**Risk level:** 🟢

**Reason for rating:** Adds GitHub Actions automation only. Manual dispatch defaults to dry run. Scheduled runs only affect pull requests without the keep label that exceed the inactivity threshold.

### Rollout

1. Merge `trade-tariff-tools` first (reusable workflow).
2. Validate on `trade-tariff-team` using the standalone pilot workflow (Actions → Close stale pull requests → dry run).
3. Merge caller workflows in other repositories after the reusable workflow is on `main`.
4. Follow-up: migrate `trade-tariff-team` from standalone to the shared reusable workflow.